### PR TITLE
Fix total messages counter

### DIFF
--- a/src/main/kotlin/me/bristermitten/devdenbot/data/AtomicBigInteger.kt
+++ b/src/main/kotlin/me/bristermitten/devdenbot/data/AtomicBigInteger.kt
@@ -15,20 +15,20 @@ import java.util.concurrent.atomic.AtomicReference
 class AtomicBigInteger(v: BigInteger) : AtomicReference<BigInteger>(v), Comparable<AtomicBigInteger> {
 
     operator fun plusAssign(other: BigInteger) {
-        getAndAccumulate(other, BigInteger::add)
+        accumulateAndGet(other, BigInteger::add)
     }
 
     operator fun plus(other: AtomicBigInteger) = AtomicBigInteger(get() + other.get())
 
     operator fun minusAssign(other: BigInteger) {
-        getAndAccumulate(other, BigInteger::minus)
+        accumulateAndGet(other, BigInteger::minus)
     }
 
     operator fun compareTo(other: BigInteger) = get().compareTo(other)
 
-    operator fun inc() = getAndAccumulate(BigInteger.ONE, BigInteger::add).atomic()
+    operator fun inc() = accumulateAndGet(BigInteger.ONE, BigInteger::add).atomic()
 
-    operator fun dec() = getAndAccumulate(BigInteger.ONE, BigInteger::minus).atomic()
+    operator fun dec() = accumulateAndGet(BigInteger.ONE, BigInteger::minus).atomic()
 
 
     companion object {

--- a/src/main/kotlin/me/bristermitten/devdenbot/stats/StatsListener.kt
+++ b/src/main/kotlin/me/bristermitten/devdenbot/stats/StatsListener.kt
@@ -1,9 +1,8 @@
 package me.bristermitten.devdenbot.stats
 
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import me.bristermitten.devdenbot.inject.Used
 import me.bristermitten.devdenbot.listener.EventListener
+import me.bristermitten.devdenbot.util.handleEachIn
 import me.bristermitten.devdenbot.util.listenFlow
 import me.bristermitten.devdenbot.util.scope
 import net.dv8tion.jda.api.JDA
@@ -12,13 +11,11 @@ import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
 @Used
 class StatsListener : EventListener {
 
-    private fun onGuildMessageReceived() {
+    internal fun onGuildMessageReceived() {
         GlobalStats.totalMessagesSent++
     }
 
     override fun register(jda: JDA) {
-        jda.listenFlow<GuildMessageReceivedEvent>()
-            .onEach { this.onGuildMessageReceived() }
-            .launchIn(scope)
+        jda.listenFlow<GuildMessageReceivedEvent>().handleEachIn(scope) { this.onGuildMessageReceived() }
     }
 }

--- a/src/test/kotlin/me/bristermitten/devdenbot/data/AtomicBigIntegerTest.kt
+++ b/src/test/kotlin/me/bristermitten/devdenbot/data/AtomicBigIntegerTest.kt
@@ -1,0 +1,49 @@
+package me.bristermitten.devdenbot.data
+
+import me.bristermitten.devdenbot.util.atomic
+import java.math.BigInteger
+import kotlin.test.*
+
+internal class AtomicBigIntegerTest {
+
+    @Test
+    fun `plusAssign adds and sets the variable`() {
+        // val works since += mutates x, while ++ reassigns x. Interesting.
+        val x = BigInteger.valueOf(5).atomic()
+        x += BigInteger.valueOf(10)
+        assertEquals(15, x.get().toInt())
+    }
+
+    @Test
+    fun `plus adds a value`() {
+        val x = BigInteger.valueOf(5).atomic()
+        val y = x + BigInteger.valueOf(10).atomic()
+        assertEquals(5, x.get().toInt())
+        assertEquals(15, y.get().toInt())
+    }
+
+    @Test
+    fun `minusAssign subtracts and sets the variable`() {
+        val x = BigInteger.valueOf(5).atomic()
+        x -= BigInteger.valueOf(10)
+        assertEquals(-5, x.get().toInt())
+    }
+
+    @Test
+    fun `inc increments and sets the variable`() {
+        var x = BigInteger.valueOf(5).atomic()
+        val result = x++
+
+        assertEquals(6, result.get().toInt())
+        assertEquals(6, x.get().toInt())
+    }
+
+    @Test
+    fun `dec decrements and sets the variable`() {
+        var x = BigInteger.valueOf(5).atomic()
+        val result = x--
+
+        assertEquals(4, result.get().toInt())
+        assertEquals(4, x.get().toInt())
+    }
+}

--- a/src/test/kotlin/me/bristermitten/devdenbot/stats/StatsListenerTest.kt
+++ b/src/test/kotlin/me/bristermitten/devdenbot/stats/StatsListenerTest.kt
@@ -1,0 +1,15 @@
+package me.bristermitten.devdenbot.stats
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class StatsListenerTest{
+
+    @Test
+    fun `onGuildMessageReceives increments messages stat` () {
+        val cut = StatsListener()
+        assertEquals(0, GlobalStats.totalMessagesSent.get().toInt())
+        cut.onGuildMessageReceived()
+        assertEquals(1, GlobalStats.totalMessagesSent.get().toInt())
+    }
+}


### PR DESCRIPTION
While plusAssign mutates the value, inc reassigns it (what??).

That's why using getAndAccumulate instead of accumulateAndGet for the inc operator will result in the variable not being incremented at all - which was the cause for the totalMessages counter not being incremented.

In this PR, I fixed this issue and added tests to confirm that the other operations still worked as intended.

May the message counting begin...