### PR TITLE
Fix no-ping warning

### DIFF
--- a/src/main/kotlin/net/developerden/devdenbot/listener/PingingListener.kt
+++ b/src/main/kotlin/net/developerden/devdenbot/listener/PingingListener.kt
@@ -28,7 +28,7 @@ class PingingListener @Inject constructor(override val ddbConfig: DDBConfig) : E
             return
         }
 
-        if (event.member?.isStaff()) {
+        if (event.member?.isStaff() == true) {
             return
         }
 

--- a/src/main/kotlin/net/developerden/devdenbot/listener/PingingListener.kt
+++ b/src/main/kotlin/net/developerden/devdenbot/listener/PingingListener.kt
@@ -28,7 +28,7 @@ class PingingListener @Inject constructor(override val ddbConfig: DDBConfig) : E
             return
         }
 
-        if (event.member?.isStaff() == false) {
+        if (event.member?.isStaff()) {
             return
         }
 


### PR DESCRIPTION
Staff members should be able to ping and not get warned, not the other way around.